### PR TITLE
feat: restore auto-sync feature

### DIFF
--- a/django_opensearch_dsl/signals.py
+++ b/django_opensearch_dsl/signals.py
@@ -1,3 +1,78 @@
+"""
+A convenient way to attach django-opensearch-dsl to Django's signals and
+cause things to index.
+"""
+
+from django.db import models
 from django.dispatch import Signal
 
+from .registries import registry
+
+
+class BaseSignalProcessor(object):
+    """Base signal processor.
+    By default, does nothing with signals but provides underlying
+    functionality.
+    """
+
+    def __init__(self, connections):
+        self.connections = connections
+        self.setup()
+
+    def setup(self):
+        """Set up.
+        A hook for setting up anything necessary for
+        ``handle_save/handle_delete`` to be executed.
+        Default behavior is to do nothing (``pass``).
+        """
+        # Do nothing.
+
+    def teardown(self):
+        """Tear-down.
+        A hook for tearing down anything necessary for
+        ``handle_save/handle_delete`` to no longer be executed.
+        Default behavior is to do nothing (``pass``).
+        """
+        # Do nothing.
+
+    def handle_m2m_changed(self, sender, instance, action, **kwargs):
+        if action in ('post_add', 'post_remove', 'post_clear'):
+            self.handle_save(sender, instance)
+
+    def handle_save(self, sender, instance, **kwargs):
+        """Handle save.
+        Given an individual model instance, update the object in the index.
+        Update the related objects either.
+        """
+        registry.update(instance)
+
+    def handle_delete(self, sender, instance, **kwargs):
+        """Handle delete.
+        Given an individual model instance, delete the object from index.
+        """
+        registry.delete(instance, raise_on_error=False)
+
+
+class RealTimeSignalProcessor(BaseSignalProcessor):
+    """Real-time signal processor.
+    Allows for observing when saves/deletes fire and automatically updates the
+    search engine appropriately.
+    """
+
+    def setup(self):
+        # Listen to all model saves.
+        models.signals.post_save.connect(self.handle_save)
+        models.signals.post_delete.connect(self.handle_delete)
+
+        # Use to manage related objects update
+        models.signals.m2m_changed.connect(self.handle_m2m_changed)
+
+    def teardown(self):
+        # Listen to all model saves.
+        models.signals.post_save.disconnect(self.handle_save)
+        models.signals.post_delete.disconnect(self.handle_delete)
+        models.signals.m2m_changed.disconnect(self.handle_m2m_changed)
+
+
+# Sent after document indexing is completed
 post_index = Signal()

--- a/tests/tests/test_signals.py
+++ b/tests/tests/test_signals.py
@@ -1,0 +1,88 @@
+from copy import copy
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from django_dummy_app.models import Continent, Country
+
+
+class SignalsTestCase(TestCase):
+    def test_saving_model_instance_triggers_update(self):
+        with patch('django_opensearch_dsl.documents.bulk') as mock:
+            # GIVEN successive names for a continent to be created/updated
+            initial_name = 'MyOwnContinent'
+            new_name = 'MyOwnPeacefulContinent'
+
+            # WHEN creating a model instance
+            # AND updating it
+            continent = Continent.objects.create(name=initial_name)
+            continent.name = new_name
+            continent.save()
+
+            # THEN it should have been indexed twice, with successive names
+            self.assertEqual(2, mock.call_count)
+            create_bulk_actions = [{
+                '_id': continent.pk,
+                '_op_type': 'index',
+                '_source': {
+                    'countries': [],
+                    'id': continent.pk,
+                    'name': initial_name,
+                },
+                '_index': 'continent',
+            }]
+            update_bulk_actions = copy(create_bulk_actions)
+            update_bulk_actions[0]['_source']['name'] = new_name
+            self.assertEqual(
+                create_bulk_actions, list(mock.call_args_list[0][1]['actions'])
+            )
+            self.assertEqual(
+                update_bulk_actions, list(mock.call_args_list[1][1]['actions'])
+            )
+
+    def test_deleting_model_instance_triggers_unindex(self):
+        with patch('django_opensearch_dsl.documents.bulk') as mock:
+            # GIVEN an existing model instance
+            continent = Continent.objects.create(name="MyOwnContinent")
+
+            # WHEN deleting it
+            continent.delete()
+
+            # THEN it should have been unindexed
+            # AND its dependant objects should have been unindexed first
+            self.assertGreaterEqual(mock.call_count, 2)
+            unindex_bulk_actions = [{
+                '_id': continent.pk,
+                '_op_type': 'delete',
+                '_index': 'continent',
+                '_source': None,
+            }]
+            self.assertEqual(
+                unindex_bulk_actions, list(mock.call_args_list[-1][1]['actions'])
+            )
+
+    def test_updating_model_instance_does_nothing_if_autosync_disabled(self):
+        with patch('django_opensearch_dsl.documents.bulk') as mock:
+            # GIVEN OPENSEARCH_DSL_AUTOSYNC is False
+            with patch(
+                'django_opensearch_dsl.apps.DEDConfig.autosync_enabled',
+                return_value=False
+            ):
+                # WHEN creating a new model instance
+                Continent.objects.create(name='MyOwnContinent')
+
+                # THEN it should not have been indexed
+                self.assertEqual(mock.call_count, 0)
+
+    def test_updating_model_instance_does_nothing_if_document_ignores_signals(self):
+        with patch('django_opensearch_dsl.documents.bulk') as mock:
+            # GIVEN ContinentDocument.django.ignore_signals is True
+            with patch(
+                'django_dummy_app.documents.ContinentDocument.django.ignore_signals',
+                return_value=True
+            ):
+                # WHEN creating a new model instance
+                Continent.objects.create(name='MyOwnContinent')
+
+                # THEN it should not have been indexed
+                self.assertEqual(mock.call_count, 0)


### PR DESCRIPTION
First attempt to fix #1 . I just retrieved the original code from django-es/django-elasticsearch-dsl. There seems to be no tests for this particular feature, but it seems covered by other tests (which is not ideal but let's give it a try). I'm not sure to understand what's been done with test in this fork, and I'm not able to run them locally, so please allow the Github Action to run so that we can see if CI is green and if coverage doesn't suffer too much.