### PR TITLE
More efficient document chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ at [https://django-opensearch-dsl.readthedocs.io](https://django-opensearch-dsl.
 
 * `Python>=3.6`
 * `django>=2.1`
+* `more-itertools~=8.12.0`
 * `opensearch-dsl~=1.0.0`
 * `python-dateutil~=2.8.2`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django>=2.1
+more-itertools~=8.12.0
 opensearch-dsl~=1.0.0
 python-dateutil~=2.8.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ LONG_DESCRIPTION = (
 )
 REQUIREMENTS = [
     'opensearch-dsl~=1.0.0',
-    'dateutils'
+    'dateutils',
+    'more-itertools',
 ]
 
 setup(


### PR DESCRIPTION
Hi there,

In our use-case, we have "only" ~150K documents, but `Document.get_queryset()` carries lots of `select_related()` and `prefetch_related()`. The resulting QuerySet is so huge that a 16GB-RAM computer cannot index anything.

Here is a proposal implementation of `Document.get_indexing_queryset()`:
* A first DB query fetches only PKs, all of them
* Then we iterate on chunks of this PK-only queryset
* For each chunk, another DB query fetches the complete queryset (with all fields and related objects)

This implementation produces more DB queries (1 + number of chunks) but has a way smaller memory footprint, and allows to index more complex documents way faster.

Let me know what you think about it.

One more thing: I introduced a dependency to `more_itertools` to get a cleaner syntax on the chunking stuff. I think that many projects are already using `more_itertools` but if you prefer without it, I can remove it easily.