### PR TITLE
fix(command): Do not use `settings.TESTING` anymore

### DIFF
--- a/django_opensearch_dsl/management/commands/opensearch.py
+++ b/django_opensearch_dsl/management/commands/opensearch.py
@@ -30,9 +30,6 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):  # noqa
         super(Command, self).__init__()
         self.usage = None
-        if settings.TESTING:  # pragma: no cover
-            self.stderr = OutputWrapper(open(os.devnull, "w"))
-            self.stdout = OutputWrapper(open(os.devnull, "w"))
 
     def db_filter(self, parser: ArgumentParser) -> Callable[[str], Any]:
         """Return a function to parse the filters."""

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -26,7 +26,6 @@ SECRET_KEY = "&l0633!(*u(rb#7^cu(+)-2@)tc+cgs96a4&^dmvov3q#g4wup"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-TESTING = sys.argv[1:2] == ["test"] or "pytest" in sys.modules
 
 ALLOWED_HOSTS = []
 

--- a/tests/tests/management/test_document.py
+++ b/tests/tests/management/test_document.py
@@ -1,3 +1,5 @@
+import functools
+import os
 import time
 
 from django.test import TestCase
@@ -5,83 +7,90 @@ from django.test import TestCase
 from django_dummy_app.commands import call_command
 from django_dummy_app.documents import CountryDocument, ContinentDocument, EventDocument
 from django_dummy_app.models import Country, Event, Continent
+from django_opensearch_dsl.registries import registry
 
 
 class DocumentTestCase(TestCase):
     fixtures = ["tests/django_dummy_app/geography_data.json"]
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        devnull = open(os.devnull, "w")
+        cls.call_command = functools.partial(call_command, stdout=devnull, stderr=devnull)
+
     def setUp(self) -> None:
-        call_command("opensearch", "index", "delete", force=True, ignore_error=True, verbosity=0)
+        indices = registry.get_indices()
+        for i in indices:
+            i.delete(ignore_unavailable=True)
 
     def test_unknown_index(self):
         with self.assertRaises(SystemExit):
-            call_command("opensearch", "document", "index", "-iunknown", verbosity=0)
+            self.call_command("opensearch", "document", "index", "-iunknown")
 
     def test_index_not_created(self):
         with self.assertRaises(SystemExit):
-            call_command("opensearch", "document", "index", f"-i{CountryDocument.Index.name}", verbosity=0)
+            self.call_command("opensearch", "document", "index", f"-i{CountryDocument.Index.name}")
 
     def test_unknown_field(self):
-        call_command("opensearch", "index", "create", CountryDocument.Index.name, verbosity=0, force=True)
+        self.call_command("opensearch", "index", "create", CountryDocument.Index.name, force=True)
         with self.assertRaises(SystemExit):
-            call_command(
+            self.call_command(
                 "opensearch",
                 "document",
                 "index",
                 f"-i{CountryDocument.Index.name}",
-                verbosity=0,
                 force=True,
                 filters=[("unknown_field", "value")],
                 refresh=True,
             )
 
     def test_index_all(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command("opensearch", "document", "index", verbosity=0, force=True, refresh=True)
+        self.call_command("opensearch", "document", "index", force=True, refresh=True)
         self.assertEqual(CountryDocument.search().count(), Country.objects.count())
         self.assertEqual(ContinentDocument.search().count(), Continent.objects.count())
         self.assertEqual(EventDocument.search().count(), Event.objects.exclude(country__name="France").count())
 
     def test_index_all_parallel(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command("opensearch", "document", "index", verbosity=0, force=True, refresh=True)
+        self.call_command("opensearch", "document", "index", force=True, refresh=True)
         self.assertEqual(CountryDocument.search().count(), Country.objects.count())
         self.assertEqual(ContinentDocument.search().count(), Continent.objects.count())
         self.assertEqual(EventDocument.search().count(), Event.objects.exclude(country__name="France").count())
 
     def test_index_one(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command(
-            "opensearch", "document", "index", f"-i{CountryDocument.Index.name}", verbosity=0, force=True, refresh=True
+        self.call_command(
+            "opensearch", "document", "index", f"-i{CountryDocument.Index.name}", force=True, refresh=True
         )
         self.assertEqual(CountryDocument.search().count(), Country.objects.count())
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
 
     def test_index_filters_equal(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command(
+        self.call_command(
             "opensearch",
             "document",
             "index",
             f"-i{CountryDocument.Index.name}",
-            verbosity=0,
             force=True,
             filters=[("continent__name", "Europe")],
             refresh=True,
@@ -94,17 +103,16 @@ class DocumentTestCase(TestCase):
         self.assertEqual(EventDocument.search().count(), 0)
 
     def test_index_filters_gte(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command(
+        self.call_command(
             "opensearch",
             "document",
             "index",
             f"-i{CountryDocument.Index.name}",
-            verbosity=0,
             force=True,
             filters=[("population__gte", 1000000)],
             refresh=True,
@@ -117,17 +125,16 @@ class DocumentTestCase(TestCase):
         self.assertEqual(EventDocument.search().count(), 0)
 
     def test_index_excludes_gte(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command(
+        self.call_command(
             "opensearch",
             "document",
             "index",
             f"-i{CountryDocument.Index.name}",
-            verbosity=0,
             force=True,
             excludes=[("population__gte", 1000000)],
             refresh=True,
@@ -140,17 +147,16 @@ class DocumentTestCase(TestCase):
         self.assertEqual(EventDocument.search().count(), 0)
 
     def test_index_filters_gte_lte(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command(
+        self.call_command(
             "opensearch",
             "document",
             "index",
             f"-i{CountryDocument.Index.name}",
-            verbosity=0,
             force=True,
             filters=[("population__gte", 1000000), ("population__lte", 10000000)],
             refresh=True,
@@ -165,17 +171,16 @@ class DocumentTestCase(TestCase):
         self.assertEqual(EventDocument.search().count(), 0)
 
     def test_index_excludes_gte_lte(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command(
+        self.call_command(
             "opensearch",
             "document",
             "index",
             f"-i{CountryDocument.Index.name}",
-            verbosity=0,
             force=True,
             excludes=[("population__gte", 1000000), ("population__lte", 10000000)],
             refresh=True,
@@ -190,38 +195,38 @@ class DocumentTestCase(TestCase):
         self.assertEqual(EventDocument.search().count(), 0)
 
     def test_index_count(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command("opensearch", "document", "index", verbosity=0, force=True, count=3, refresh=True)
+        self.call_command("opensearch", "document", "index", force=True, count=3, refresh=True)
         self.assertEqual(ContinentDocument.search().count(), 3)
         self.assertEqual(CountryDocument.search().count(), 3)
         self.assertEqual(EventDocument.search().count(), 3)
 
     def test_index_missing(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command("opensearch", "document", "index", verbosity=0, force=True, count=3, refresh=True)
+        self.call_command("opensearch", "document", "index", force=True, count=3, refresh=True)
         self.assertEqual(ContinentDocument.search().count(), 3)
         self.assertEqual(CountryDocument.search().count(), 3)
         self.assertEqual(EventDocument.search().count(), 3)
-        call_command("opensearch", "document", "index", verbosity=0, force=True, missing=True, refresh=True)
+        self.call_command("opensearch", "document", "index", force=True, missing=True, refresh=True)
         self.assertEqual(CountryDocument.search().count(), Country.objects.count())
         self.assertEqual(ContinentDocument.search().count(), Continent.objects.count())
         self.assertEqual(EventDocument.search().count(), Event.objects.exclude(country__name="France").count())
 
     def test_index_not_refresh(self):
-        call_command("opensearch", "index", "create", force=True, verbosity=0)
+        self.call_command("opensearch", "index", "create", force=True)
 
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)
-        call_command("opensearch", "document", "index", verbosity=0, force=True, count=3)
+        self.call_command("opensearch", "document", "index", force=True, count=3)
         self.assertEqual(ContinentDocument.search().count(), 0)
         self.assertEqual(CountryDocument.search().count(), 0)
         self.assertEqual(EventDocument.search().count(), 0)

--- a/tests/tests/test_search.py
+++ b/tests/tests/test_search.py
@@ -1,19 +1,21 @@
 from django.test import TestCase
 from opensearch_dsl import Q
 
-from django_dummy_app.commands import call_command
 from django_dummy_app.documents import CountryDocument, ContinentDocument
 from django_dummy_app.models import Country, Continent
+from django_opensearch_dsl.registries import registry
 
 
 class DocumentTestCase(TestCase):
     fixtures = ["tests/django_dummy_app/geography_data.json"]
 
     def setUp(self) -> None:
-        call_command("opensearch", "index", "delete", force=True, ignore_error=True, verbosity=0)
+        indices = registry.get_indices()
+        for i in indices:
+            i.delete(ignore_unavailable=True)
 
     def test_search_country(self):
-        call_command("opensearch", "index", "create", CountryDocument.Index.name, force=True, verbosity=0)
+        CountryDocument._index.create()
 
         CountryDocument().update(CountryDocument().get_indexing_queryset(), "index", refresh=True)
         self.assertEqual(
@@ -22,7 +24,7 @@ class DocumentTestCase(TestCase):
         )
 
     def test_search_country_cache(self):
-        call_command("opensearch", "index", "create", CountryDocument.Index.name, force=True, verbosity=0)
+        CountryDocument._index.create()
 
         CountryDocument().update(CountryDocument().get_indexing_queryset(), "index", refresh=True)
         search = CountryDocument.search().query("term", **{"continent.name": "Europe"}).extra(size=300)
@@ -32,7 +34,7 @@ class DocumentTestCase(TestCase):
         )
 
     def test_search_country_keep_order(self):
-        call_command("opensearch", "index", "create", CountryDocument.Index.name, force=True, verbosity=0)
+        CountryDocument._index.create()
 
         CountryDocument().update(CountryDocument().get_indexing_queryset(), "index", refresh=True)
         search = CountryDocument.search().query("term", **{"continent.name": "Europe"}).extra(size=300)
@@ -41,7 +43,7 @@ class DocumentTestCase(TestCase):
         )
 
     def test_search_country_refresh_default_to_document(self):
-        call_command("opensearch", "index", "create", CountryDocument.Index.name, force=True, verbosity=0)
+        CountryDocument._index.create()
 
         CountryDocument().update(CountryDocument().get_indexing_queryset(), "index", refresh=True)
         self.assertEqual(
@@ -50,7 +52,7 @@ class DocumentTestCase(TestCase):
         )
 
     def test_search_country_refresh_default_to_settings(self):
-        call_command("opensearch", "index", "create", ContinentDocument.Index.name, force=True, verbosity=0)
+        ContinentDocument._index.create()
 
         ContinentDocument().update(ContinentDocument().get_indexing_queryset(), "index", refresh=True)
         search = ContinentDocument.search().query(
@@ -59,7 +61,8 @@ class DocumentTestCase(TestCase):
         self.assertEqual(set(search.to_queryset()), set(Continent.objects.filter(countries__name="France")))
 
     def test_update_instance(self):
-        call_command("opensearch", "index", "create", ContinentDocument.Index.name, force=True, verbosity=0)
+        ContinentDocument._index.create()
+
         ContinentDocument().update(Continent.objects.get(countries__name="France"), "index", refresh=True)
         search = ContinentDocument.search().query(
             "nested", path="countries", query=Q("term", **{"countries.name": "France"})


### PR DESCRIPTION
`settings.TESTING` was used to disable `stdout` and `stderr` during testing,
but it is not a standard Django settings. `stdout` and `stderr` must instead be
redirected using their correpsonding argument of `call_command`[1].

If the commands are not being directly tested, it is also better to use
`Document` and `Document._index` to manage indices and documents.

[1] https://docs.djangoproject.com/en/4.0/topics/testing/tools/#management-commands

Issues: #10 