### PR TITLE
Added action bugfix and added pre-delete method to m2m_changed

### DIFF
--- a/django_opensearch_dsl/registries.py
+++ b/django_opensearch_dsl/registries.py
@@ -91,7 +91,7 @@ class DocumentRegistry:
                 if instance.__class__ in doc.django.related_models:
                     yield doc
 
-    def update_related(self, instance, **kwargs):
+    def update_related(self, instance, action="index", **kwargs):
         """Update documents related to `instance`.
 
         Related documents are found using the `get_instances_from_related()`
@@ -109,9 +109,9 @@ class DocumentRegistry:
                 related = None
 
             if related is not None:
-                doc_instance.update(related, **kwargs)
+                doc_instance.update(related, action, **kwargs)
 
-    def delete_related(self, instance, **kwargs):
+    def delete_related(self, instance, action="index", **kwargs):
         """Remove `instance` from related models.
 
         `related_instance_to_ignore` ensures that `instance` is only removed
@@ -129,7 +129,7 @@ class DocumentRegistry:
                 related = None
 
             if related is not None:
-                doc_instance.update(related, **kwargs)
+                doc_instance.update(related, action, **kwargs)
 
     def update(self, instance, action="index", **kwargs):
         """Update all the opensearch documents attached to this model.

--- a/django_opensearch_dsl/signals.py
+++ b/django_opensearch_dsl/signals.py
@@ -41,6 +41,8 @@ class BaseSignalProcessor(object):
         """Handle changes in ManyToMany relations."""
         if action in ("post_add", "post_remove", "post_clear"):
             self.handle_save(sender, instance)
+        elif action in ("pre_remove", "pre_clear"):
+            self.handle_pre_delete(sender, instance)
 
     def handle_save(self, sender, instance, **kwargs):
         """Handle save.

--- a/tests/tests/test_registries.py
+++ b/tests/tests/test_registries.py
@@ -83,9 +83,9 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
         self.registry.update_related(instance_e)
 
         doc_d1.get_instances_from_related.assert_called_once_with(instance_e)
-        doc_d1.update.assert_called_once_with(related_instance)
+        doc_d1.update.assert_called_once_with(related_instance, "index")
         doc_d2.get_instances_from_related.assert_called_once_with(instance_e)
-        doc_d2.update.assert_called_once_with(related_instance)
+        doc_d2.update.assert_called_once_with(related_instance, "index")
 
         doc_d1.get_instances_from_related.reset_mock()
         doc_d1.update.reset_mock()
@@ -94,7 +94,7 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
 
         self.registry.update_related(instance_b)
         doc_d1.get_instances_from_related.assert_called_once_with(instance_b)
-        doc_d1.update.assert_called_once_with(related_instance)
+        doc_d1.update.assert_called_once_with(related_instance, "index")
         doc_d2.get_instances_from_related.assert_not_called()
         doc_d2.update.assert_not_called()
 
@@ -136,7 +136,7 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
         self.registry.delete_related(instance)
 
         doc_d1.get_instances_from_related.assert_called_once_with(instance)
-        doc_d1.update.assert_called_once_with(related_instance)
+        doc_d1.update.assert_called_once_with(related_instance, "index")
 
     def test_delete_related_instance_not_defined(self):
         """


### PR DESCRIPTION
Quick fix for #21 by adding required argument that was missed due to mocking. Also adds pre-delete back into handle_m2m_changed() which allows the index to update properly on m2m interactions. Otherwise, it may still be possible to end up with orphaned references.