### PR TITLE
fix: Set `keep_order` arg of `Search.to_queryset()` to `True`

### DIFF
--- a/django_opensearch_dsl/search.py
+++ b/django_opensearch_dsl/search.py
@@ -17,7 +17,7 @@ class Search(DSLSearch):
         s._model = self._model
         return s
 
-    def to_queryset(self, keep_order=False):
+    def to_queryset(self, keep_order=True):
         """Return a django queryset corresponding to the opensearch result."""
         s = self
 


### PR DESCRIPTION
Set default value of `keep_order` to `True` in the `Search.to_queryset` method in accordance of upstream and how it is implied in the documentation.

---

Fixes #27 