### PR TITLE
Change references from opensource_dsl to opensourcepy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Django Opensearch DSL
 [![CodeFactor](https://www.codefactor.io/repository/github/Codoc-os/django-opensearch-dsl/badge)](https://www.codefactor.io/repository/github/Codoc-os/django-opensearch-dsl)
 
 **Django Opensearch DSL** is a package that allows the indexing of Django models in opensearch. It is built as a thin
-wrapper around [`opensearch-dsl-py`](https://github.com/opensearch-project/opensearch-dsl-py)
-so you can use all the features developed by the `opensearch-dsl` team.
+wrapper around [`opensearch-py`](https://github.com/opensearch-project/opensearch-py)
+so you can use all the features developed by the `opensearch-py` team.
 
 You can view the full documentation
 at [https://django-opensearch-dsl.readthedocs.io](https://django-opensearch-dsl.readthedocs.io/en/latest/).
 
 ## Features
 
-- Based on [`opensearch-dsl-py`](https://github.com/opensearch-project/opensearch-dsl-py) so you can make queries with
+- Based on [`opensearch-py`](https://github.com/opensearch-project/opensearch-py) so you can make queries with
   the [`Search`](https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#the-search-object)
   object.
 - Management commands for creating, deleting, and populating indices and documents.
@@ -33,7 +33,7 @@ at [https://django-opensearch-dsl.readthedocs.io](https://django-opensearch-dsl.
 
 * `Python>=3.7`
 * `django>=3.2`
-* `opensearch-dsl>=1.0.0, <3.0.0`
+* `opensearch-py>=1.0.0, <3.0.0`
 * `python-dateutil~=2.8.2`
 
 ## Installation and Configuration

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OPENSEARCH_DSL = {
 ```
 
 `OPENSEARCH_DSL` is then passed
-to [`opensearch_dsl_py.connections.configure`](http://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters)
+to [`opensearchpy.connection.connections.configure`](http://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters)
 .
 
 ## Create Document Classes

--- a/develop_requirements.txt
+++ b/develop_requirements.txt
@@ -1,5 +1,5 @@
 django>=2.1
-opensearch-dsl~=1.0.0
+opensearch-py~=1.0.0
 python-dateutil~=2.8.2
 black~=22.3.0
 pycodestyle~=2.8.0

--- a/django_opensearch_dsl/apps.py
+++ b/django_opensearch_dsl/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.utils.module_loading import import_string
 
-from opensearch_dsl.connections import connections
+from opensearchpy.connection.connections import connections
 
 
 class DODConfig(AppConfig):

--- a/django_opensearch_dsl/documents.py
+++ b/django_opensearch_dsl/documents.py
@@ -7,7 +7,7 @@ from typing import Optional, Iterable
 
 from django.db import models
 from django.db.models import QuerySet, Q
-from opensearchpy.helpers.documents import Document as DSLDocument
+from opensearchpy.helpers.document import Document as DSLDocument
 from opensearchpy.helpers import bulk, parallel_bulk
 
 from . import fields

--- a/django_opensearch_dsl/documents.py
+++ b/django_opensearch_dsl/documents.py
@@ -7,7 +7,7 @@ from typing import Optional, Iterable
 
 from django.db import models
 from django.db.models import QuerySet, Q
-from opensearch_dsl import Document as DSLDocument
+from opensearchpy.helpers.documents import Document as DSLDocument
 from opensearchpy.helpers import bulk, parallel_bulk
 
 from . import fields

--- a/django_opensearch_dsl/fields.py
+++ b/django_opensearch_dsl/fields.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models.fields.files import FieldFile
 from django.utils.encoding import force_str
 from django.utils.functional import Promise
-from opensearch_dsl import field as fields
+from opensearchpy.helpers import field as fields
 
 from .exceptions import VariableLookupError
 

--- a/django_opensearch_dsl/indices.py
+++ b/django_opensearch_dsl/indices.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from opensearch_dsl import Index as DSLIndex
+from opensearchpy.helpers.index import Index as DSLIndex
 
 from .apps import DODConfig
 from .registries import registry

--- a/django_opensearch_dsl/registries.py
+++ b/django_opensearch_dsl/registries.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ImproperlyConfigured
-from opensearch_dsl import AttrDict
+from opensearchpy.helpers.utils import AttrDict
 
 from .apps import DODConfig
 from .exceptions import RedeclaredFieldError

--- a/django_opensearch_dsl/search.py
+++ b/django_opensearch_dsl/search.py
@@ -1,12 +1,12 @@
 from django.db.models import Case, When
 from django.db.models.fields import IntegerField
 
-from opensearch_dsl import Search as DSLSearch
-from opensearch_dsl.connections import connections
+from opensearchpy.helpers.search import Search as DSLSearch
+from opensearchpy.connection.connections import connections
 
 
 class Search(DSLSearch):
-    """Subclass of `opensearch_dsl.Search` with some utility methods."""
+    """Subclass of `opensearchpy.helpers.search.Search` with some utility methods."""
 
     def __init__(self, **kwargs):
         self._model = kwargs.pop("model", None)

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2,7 +2,7 @@ Document Field Reference
 ========================
 
 The `django_opensearch_dsl.fields` are subclasses
-of [`opensearch-dsl-py`'s fields](http://elasticsearch-dsl.readthedocs.io/en/stable/persistence.html#mappings). They
+of [`opensearch-py`'s fields](http://elasticsearch-dsl.readthedocs.io/en/stable/persistence.html#mappings). They
 just add support for retrieving data from Django models.
 
 ## Available Fields

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -26,7 +26,7 @@ OPENSEARCH_DSL = {
 ```
 
 `OPENSEARCH_DSL` is then passed
-to [`opensearch_dsl.connections.configure`](http://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters)
+to [`opensearchpy.connection.connections.configure`](http://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters)
 .
 
 ## Create Document Classes

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,7 +102,7 @@ See [management commands](management.md) for more information.
 ## Search
 
 To get
-an `opensearch-dsl` [`Search`](https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#the-search-object)
+an `opensearch-py` [`Search`](https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#the-search-object)
 instance, use:
 
 ```python
@@ -117,7 +117,7 @@ for hit in s:
 ```
 
 The previous example returns a result specific
-to [`opensearch-dsl`](http://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#response), but it is also
+to [`opensearch-py`](http://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#response), but it is also
 possible to convert the opensearch result into a real Django queryset, just be aware that this costs a SQL request to
 retrieve the model instances with the ids returned by the opensearch query.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -24,7 +24,7 @@ to [`opensearchpy.connection.connections.configure()`](http://elasticsearch-dsl.
 
 Default: `{}`
 
-Additional options passed to the `opensearch-dsl` Index settings (like `number_of_replicas` or `number_of_shards`).
+Additional options passed to the `opensearch-py` Index settings (like `number_of_replicas` or `number_of_shards`).
 See [Opensearch's index settings](https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/#index-settings)
 for more information.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,7 +17,7 @@ OPENSEARCH_DSL = {
 ```
 
 `OPENSEARCH_DSL` is passed
-to [`opensearch_dsl_py.connections.configure()`](http://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters)
+to [`opensearchpy.connection.connections.configure()`](http://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters)
 .
 
 ## `OPENSEARCH_DSL_INDEX_SETTINGS`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=2.1
-opensearch-dsl>=1.0.0, <3.0.0
+opensearch-py>=1.0.0, <3.0.0
 python-dateutil~=2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=2.1
-opensearch-py>=1.0.0, <3.0.0
+opensearch-py>=2.2.0
 python-dateutil~=2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,8 @@ deps =
     django32: django>=3.2.0,<3.3.0
     django40: django>=4.0.0,<4.1.0
     django41: django>=4.1.0,<4.2.0
-    opensearch10: opensearch-py>=1.0.0, <2.0.0
-    opensearch20: opensearch-py>=2.0.0, <3.0.0
+    opensearch10: opensearch-py>=2.2.0
+    opensearch20: opensearch-py>=2.2.0
     pycodestyle
     pydocstyle
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,8 @@ deps =
     django32: django>=3.2.0,<3.3.0
     django40: django>=4.0.0,<4.1.0
     django41: django>=4.1.0,<4.2.0
-    opensearch10: opensearch-dsl>=1.0.0, <2.0.0
-    opensearch20: opensearch-dsl>=2.0.0, <3.0.0
+    opensearch10: opensearch-py>=1.0.0, <2.0.0
+    opensearch20: opensearch-py>=2.0.0, <3.0.0
     pycodestyle
     pydocstyle
     pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ LONG_DESCRIPTION = (
     + codecs.open(os.path.join(DIRNAME, 'docs/CHANGELOG.md'), encoding='utf-8').read()
 )
 REQUIREMENTS = [
-    'opensearch-dsl>=1.0.0, <3.0.0',
+    'opensearch-py>=1.0.0, <3.0.0',
     'dateutils'
 ]
 
 setup(
     name='django-opensearch-dsl',
     version='0.5.0',
-    description="""Wrapper around opensearch-dsl-py for django models""",
+    description="""Wrapper around opensearch-py for django models""",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
     author='Quentin Coumes (Codoc)',
@@ -44,6 +44,6 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     license="Apache Software License 2.0",
-    keywords='django elasticsearch elasticsearch-dsl opensearch opensearch-dsl',
+    keywords='django elasticsearch elasticsearch-dsl opensearch opensearch-dsl opensearch-py',
     classifiers=CLASSIFIERS,
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ LONG_DESCRIPTION = (
     + codecs.open(os.path.join(DIRNAME, 'docs/CHANGELOG.md'), encoding='utf-8').read()
 )
 REQUIREMENTS = [
-    'opensearch-py>=1.0.0, <3.0.0',
+    'opensearch-py>=2.2.0',
     'dateutils'
 ]
 

--- a/tests/django_dummy_app/documents.py
+++ b/tests/django_dummy_app/documents.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from django.db.models import QuerySet
-from opensearch_dsl import Q
+from opensearchpy.helpers.query import Q
 
 from django_opensearch_dsl import Document, fields
 from django_opensearch_dsl.registries import registry

--- a/tests/tests/test_documents.py
+++ b/tests/tests/test_documents.py
@@ -4,7 +4,8 @@ from django.conf import settings
 from django.db import models
 from django.test import TestCase, override_settings
 from django.utils.translation import gettext_lazy as _
-from opensearchpy.helpers.field import GeoPoint, InnerDoc
+from opensearchpy.helpers.field import GeoPoint
+from opensearchpy.helpers.document import InnerDoc
 from opensearchpy import OpenSearch
 
 from django_opensearch_dsl import fields

--- a/tests/tests/test_documents.py
+++ b/tests/tests/test_documents.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.test import TestCase, override_settings
 from django.utils.translation import gettext_lazy as _
-from opensearch_dsl import GeoPoint, InnerDoc
+from opensearchpy.helpers.field import GeoPoint, InnerDoc
 from opensearchpy import OpenSearch
 
 from django_opensearch_dsl import fields

--- a/tests/tests/test_search.py
+++ b/tests/tests/test_search.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from opensearch_dsl import Q
+from opensearchpy.helpers.query import Q
 
 from django_dummy_app.documents import CountryDocument, ContinentDocument
 from django_dummy_app.models import Country, Continent


### PR DESCRIPTION
As I mentioned in https://github.com/Codoc-os/django-opensearch-dsl/issues/32, opensource_dsl_py is deprecated. This changes our references to opensource_py