### PR TITLE
fix: add compatibility for update on polymorphic models

### DIFF
--- a/django_opensearch_dsl/registries.py
+++ b/django_opensearch_dsl/registries.py
@@ -88,7 +88,10 @@ class DocumentRegistry:
     def _get_related_doc(self, instance):
         for model in self._related_models.get(instance.__class__, []):
             for doc in self._models[model]:
-                if instance.__class__ in doc.django.related_models:
+                if (
+                    instance.__class__ in doc.django.related_models
+                    or instance.__class__.__base__ in doc.django.related_models
+                ):
                     yield doc
 
     def update_related(self, instance, action="index", **kwargs):
@@ -142,6 +145,11 @@ class DocumentRegistry:
 
         if instance.__class__ in self._models:
             for doc in self._models[instance.__class__]:
+                if not doc.django.ignore_signals:
+                    doc().update(instance, action, **kwargs)
+
+        if instance.__class__.__base__ in self._models:
+            for doc in self._models[instance.__class__.__base__]:
                 if not doc.django.ignore_signals:
                     doc().update(instance, action, **kwargs)
 


### PR DESCRIPTION
This handles the case when trying to declare a document of a polymorphic model, like the ones defined in the [django-polymorphic](https://django-polymorphic.readthedocs.io/en/stable/) library.

More details are specified on #35 