### PR TITLE
Add the missing default parameter to the inner function's parameters

### DIFF
--- a/django_opensearch_dsl/fields.py
+++ b/django_opensearch_dsl/fields.py
@@ -145,7 +145,7 @@ def ListField(field):  # noqa
 
     original_get_value_from_instance = field.get_value_from_instance
 
-    def get_value_from_instance(self, instance):
+    def get_value_from_instance(self, instance, field_value_to_ignore=None):
         if not original_get_value_from_instance(instance):  # pragma: no cover
             return []
         return [value for value in original_get_value_from_instance(instance)]


### PR DESCRIPTION
The `get_value_from_instance` function defined as an inner function in ListField is missing the default parameter. 
This causes an Error when `get_value_from_instance` is called from others. 
This happens because the function is passed two arguments where it is called, but is only defined as `self`, `instance`.