### PR TITLE
Add get_models() and __contains__() in registries.py

### DIFF
--- a/django_opensearch_dsl/registries.py
+++ b/django_opensearch_dsl/registries.py
@@ -162,9 +162,7 @@ class DocumentRegistry:
         self.update(instance, action="delete", **kwargs)
 
     def get_models(self):
-        """
-        Get all models in the registry
-        """
+        """Get all models in the registry."""
         return set(self._models.keys())
 
     def get_indices(self, models=None):
@@ -175,9 +173,8 @@ class DocumentRegistry:
         return set(self._indices.keys())
 
     def __contains__(self, model):
-        """
-        Checks that model is in registry
-        """
+        """Checks that model is in registry."""
         return model in self._models or model in self._related_models
+
 
 registry = DocumentRegistry()

--- a/django_opensearch_dsl/registries.py
+++ b/django_opensearch_dsl/registries.py
@@ -161,6 +161,12 @@ class DocumentRegistry:
         """
         self.update(instance, action="delete", **kwargs)
 
+    def get_models(self):
+        """
+        Get all models in the registry
+        """
+        return set(self._models.keys())
+
     def get_indices(self, models=None):
         """Get all indices in the registry or the indices for a list of models."""
         if models is not None:
@@ -168,5 +174,10 @@ class DocumentRegistry:
 
         return set(self._indices.keys())
 
+    def __contains__(self, model):
+        """
+        Checks that model is in registry
+        """
+        return model in self._models or model in self._related_models
 
 registry = DocumentRegistry()


### PR DESCRIPTION
In `django-elasticsearch-dsl`'s `registries.py`, a public method exists to retrieve a list of registered models. 
Also, it can easily check if a particular model is registered by defining the `__contains__` method.
The change is to add these two functions.