### PR TITLE
feat: Implement `get_documents()` for `DocumentRegistry`

### DIFF
--- a/django_opensearch_dsl/registries.py
+++ b/django_opensearch_dsl/registries.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from copy import deepcopy
+from itertools import chain
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db.models import Model
@@ -160,6 +161,14 @@ class DocumentRegistry:
         `Document'`s `ignore_signals` is `False`.
         """
         self.update(instance, action="delete", **kwargs)
+
+    def get_documents(self, models=None):
+        """Get all documents in the registry or the documents for a list of models."""
+        if models is not None:
+            docs_iter = (self._models[model] for model in models if model in self._models)
+        else:
+            docs_iter = self._models.values()
+        return set(chain.from_iterable(docs_iter))
 
     def get_models(self):
         """Get all models in the registry."""

--- a/tests/tests/test_registries.py
+++ b/tests/tests/test_registries.py
@@ -57,6 +57,14 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
         ModelC = Mock()
         self.assertFalse(self.registry.get_indices([ModelC]))
 
+    def test_get_documents(self):
+        docs = {self.doc_a1, self.doc_a2, self.doc_b1, self.doc_c1, self.doc_d1, self.doc_e1}
+        self.assertEqual(self.registry.get_documents(), docs)
+
+    def test_get_documents_by_models(self):
+        docs = {self.doc_a1, self.doc_a2, self.doc_b1}
+        self.assertEqual(self.registry.get_documents(models=[self.ModelA, self.ModelB]), docs)
+
     def test_get_models(self):
         self.assertEqual(self.registry.get_models(), {self.ModelA, self.ModelB, self.ModelC, self.ModelD, self.ModelE})
 


### PR DESCRIPTION
This PR implements the `get_documents()` method for `DocumentRegistry`, similar to the one provided in [django-elasticsearch-dsl](https://github.com/django-es/django-elasticsearch-dsl/blob/e453afffe024725be27e457cdf67b1e8229bccfe/django_elasticsearch_dsl/registries.py#L150).