### PR TITLE
build and publish a wheel

### DIFF
--- a/.github/workflows/tests_and_publish.yml
+++ b/.github/workflows/tests_and_publish.yml
@@ -180,8 +180,8 @@ jobs:
 
       - name: Creating Built Distributions
         run: |
-          pip install setuptools
-          python setup.py sdist
+          pip install build
+          python -m build
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I notice that this project currently publishes only a source distribution, no wheel.  Publish both.

(Also direct invocation of setup.py is deprecated)